### PR TITLE
implement smooth zooming and scrolling

### DIFF
--- a/src/graphicsscene.cpp
+++ b/src/graphicsscene.cpp
@@ -975,49 +975,6 @@ namespace Caneda
         sendMouseActionEvent(event);
     }
 
-    void GraphicsScene::wheelEvent(QGraphicsSceneWheelEvent *event)
-    {
-        QGraphicsView *v = static_cast<QGraphicsView *>(event->widget()->parent());
-        GraphicsView *sv = qobject_cast<GraphicsView*>(v);
-        if(!sv) {
-            return;
-        }
-
-        if(event->modifiers() & Qt::ControlModifier){
-
-            if(event->delta() > 0) {
-                sv->translate(0,50);
-            }
-            else {
-                sv->translate(0,-50);
-            }
-
-        }
-        else if(event->modifiers() & Qt::ShiftModifier){
-
-            if(event->delta() > 0) {
-                sv->translate(-50,0);
-            }
-            else {
-                sv->translate(50,0);
-            }
-        }
-        else{
-
-            sv->setTransformationAnchor(QGraphicsView::AnchorUnderMouse);  // Set transform to zoom into mouse position
-
-            if(event->delta() > 0) {
-                sv->zoomIn();
-            }
-            else {
-                sv->zoomOut();
-            }
-
-        }
-
-        event->accept();
-    }
-
     /*!
      * \brief Constructs and returns a context menu with the actions
      * corresponding to the selected object.

--- a/src/graphicsscene.h
+++ b/src/graphicsscene.h
@@ -133,7 +133,6 @@ namespace Caneda
         void mouseReleaseEvent(QGraphicsSceneMouseEvent *event);
         void mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event);
 
-        void wheelEvent(QGraphicsSceneWheelEvent *event);
         void contextMenuEvent(QGraphicsSceneContextMenuEvent *event);
 
     private:

--- a/src/graphicsview.h
+++ b/src/graphicsview.h
@@ -24,6 +24,7 @@
 #include "global.h"
 
 #include <QGraphicsView>
+#include <QTimeLine>
 
 namespace Caneda
 {
@@ -60,6 +61,7 @@ namespace Caneda
         void zoomOut();
         void zoomFitInBest();
         void zoomOriginal();
+        void zoomDelta(qreal delta, const QPointF& centre);
         void zoomFitRect(const QRectF &rect);
 
         qreal currentZoom() { return m_currentZoom; }
@@ -70,6 +72,7 @@ namespace Caneda
         void focussedOut(GraphicsView *view);
 
     protected:
+        void wheelEvent(QWheelEvent *event);
         void mousePressEvent(QMouseEvent *event);
         void mouseMoveEvent(QMouseEvent *event);
         void mouseReleaseEvent(QMouseEvent *event);
@@ -78,13 +81,19 @@ namespace Caneda
 
     private Q_SLOTS:
         void onMouseActionChanged(Caneda::MouseAction mouseAction);
+        void smoothZoomEvent(qreal step);
 
     private:
-        void setZoomLevel(qreal zoomLevel);
+        void smoothZoom(qreal desiredZoom);
+        void smoothZoom(qreal desiredZoom, const QPointF& centre);
+        void setZoomLevel(qreal zoomLevel, const QPointF& centre);
 
+        QTimeLine* m_currentZoomAnimation;
         const qreal m_zoomFactor;
         ZoomRange m_zoomRange;
         qreal m_currentZoom;
+        qreal m_desiredZoom;
+        QPointF m_zoomCentre;
 
         //! \brief Auxiliary pan variables
         bool panMode;


### PR DESCRIPTION
This moves the scroll handling from GraphicsScene to GraphicsView, and fixes it to take the amount of pixels moved into account. This makes it very smooth on high res scrolling devices like some Logitech mice and trackpads.

It also fixes the zoom behaviour to zoom smoothly in a similar way.